### PR TITLE
Fix cookie_path: use absolute path for Docker compatibility

### DIFF
--- a/ncore.py
+++ b/ncore.py
@@ -55,7 +55,7 @@ class ncore(object):
     passhash = 'should leave empty if dont know'
     twofactorcode = 'enter_code'
 
-    cookie_path = '/config/data/nova3/engines/cookies.txt'
+    cookie_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'cookies.txt')
     allowed_cookies = ['nick', 'pass', 'stilus', 'nyelv']
 
     MAX_PAGE_NUMBER = 10

--- a/ncore.py
+++ b/ncore.py
@@ -55,7 +55,7 @@ class ncore(object):
     passhash = 'should leave empty if dont know'
     twofactorcode = 'enter_code'
 
-    cookie_path = 'cookies.txt'
+    cookie_path = '/config/data/nova3/engines/cookies.txt'
     allowed_cookies = ['nick', 'pass', 'stilus', 'nyelv']
 
     MAX_PAGE_NUMBER = 10


### PR DESCRIPTION
When running inside a hotio/qbittorrent Docker container, cookie_path = 'cookies.txt'  saved the session cookie to the container root (/cookies.txt).  Since qBittorrent runs the plugin from a different working directory,  the cookie was never found and login failed silently on every search,  resulting in 0 results.

Fix: use absolute path /config/data/nova3/engines/cookies.txt

Tested on: Raspberry Pi 5, hotio/qbittorrent:release-5.0.4, Python 3.12.9